### PR TITLE
Turn off parameter hints

### DIFF
--- a/config/options/editor.xml
+++ b/config/options/editor.xml
@@ -2,5 +2,6 @@
   <component name="EditorSettings">
     <option name="IS_ENSURE_NEWLINE_AT_EOF" value="true" />
     <option name="ARE_LINE_NUMBERS_SHOWN" value="true" />
+    <option name="SHOW_PARAMETER_NAME_HINTS" value="false" />
   </component>
 </application>


### PR DESCRIPTION
I find these pretty annoying and wonder if others agree.

Before:

![screen shot 2017-08-01 at 3 08 21 pm](https://user-images.githubusercontent.com/12998/28849509-2693603c-76cc-11e7-9018-eb861ccd1832.png)


After:

![screen shot 2017-08-01 at 3 07 50 pm](https://user-images.githubusercontent.com/12998/28849511-2a5cf0ca-76cc-11e7-84c7-7e6fb860e719.png)

My main issue is that it screws up where you put the cursor to change the values. For example, here is where you need to put the cursor in order to change the number 2:

![screen shot 2017-08-01 at 3 08 36 pm](https://user-images.githubusercontent.com/12998/28849515-2e90c6bc-76cc-11e7-81a6-ece7a7e1222e.png)

I feel like if you don't know the args to a method, it's pretty easy to pretty `ctrl-j` which pops up a description of the method.