### PR TITLE
Add new required section for Save Actions

### DIFF
--- a/config/options/project.default.xml
+++ b/config/options/project.default.xml
@@ -104,6 +104,15 @@
           <method />
         </configuration>
       </component>
+      <component name="SaveActionSettings">
+        <option name="actions">
+          <set>
+            <option value="activate" />
+            <option value="organizeImports" />
+            <option value="reformat" />
+          </set>
+        </option>
+      </component>
       <component name="masterDetails">
         <states>
           <state key="ProjectJDKs.UI">


### PR DESCRIPTION
Save Actions seems to have stopped working (presumably after an upgrade of either the plugin or IntelliJ). This diff is the result of turning it off and back on with a fresh clone. It seems to fix the issue.