### PR TITLE
Upgrade from oracle-java-8 to openjdk-11

### DIFF
--- a/config/options/jdk.table.xml
+++ b/config/options/jdk.table.xml
@@ -1,10 +1,10 @@
 <application>
   <component name="ProjectJdkTable">
     <jdk version="2">
-      <name value="1.8" />
+      <name value="11" />
       <type value="JavaSDK" />
-      <version value="java version &quot;1.8.0_91&quot;" />
-      <homePath value="/usr/lib/jvm/java-8-oracle" />
+      <version value="java version &quot;11&quot;" />
+      <homePath value="/opt/jdk-11" />
       <roots>
         <annotationsPath>
           <root type="composite">
@@ -13,27 +13,76 @@
         </annotationsPath>
         <classPath>
           <root type="composite">
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/charsets.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/deploy.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/cldrdata.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/dnsns.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/jaccess.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/jfxrt.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/localedata.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/nashorn.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/sunec.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/sunjce_provider.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/sunpkcs11.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/zipfs.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/javaws.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/jce.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/jfr.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/jfxswt.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/jsse.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/management-agent.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/plugin.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/resources.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/rt.jar!/" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.base" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.compiler" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.datatransfer" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.desktop" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.instrument" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.logging" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.management" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.management.rmi" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.naming" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.net.http" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.prefs" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.rmi" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.scripting" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.se" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.security.jgss" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.security.sasl" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.smartcardio" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.sql" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.sql.rowset" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.transaction.xa" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.xml" type="simple" />
+            <root url="jrt:///opt/jdk-11!/java.xml.crypto" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.accessibility" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.aot" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.attach" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.charsets" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.compiler" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.crypto.cryptoki" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.crypto.ec" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.dynalink" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.editpad" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.hotspot.agent" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.httpserver" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.internal.ed" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.internal.jvmstat" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.internal.le" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.internal.opt" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.internal.vm.ci" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.internal.vm.compiler" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.internal.vm.compiler.management" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.jartool" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.javadoc" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.jcmd" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.jconsole" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.jdeps" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.jdi" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.jdwp.agent" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.jfr" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.jlink" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.jshell" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.jsobject" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.jstatd" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.localedata" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.management" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.management.agent" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.management.jfr" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.naming.dns" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.naming.rmi" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.net" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.pack" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.rmic" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.scripting.nashorn" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.scripting.nashorn.shell" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.sctp" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.security.auth" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.security.jgss" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.unsupported" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.unsupported.desktop" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.xml.dom" type="simple" />
+            <root url="jrt:///opt/jdk-11!/jdk.zipfs" type="simple" />
           </root>
         </classPath>
         <javadocPath>
@@ -41,8 +90,76 @@
         </javadocPath>
         <sourcePath>
           <root type="composite">
-            <root url="jar:///usr/lib/jvm/java-8-oracle/src.zip!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/javafx-src.zip!/" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.se" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.aot" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.jdi" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.jfr" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.net" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.rmi" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.sql" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.xml" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.jcmd" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.pack" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.rmic" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.sctp" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.base" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.jdeps" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.jlink" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.zipfs" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.prefs" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.attach" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.jshell" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.jstatd" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.naming" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.editpad" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.jartool" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.javadoc" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.xml.dom" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.desktop" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.logging" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.charsets" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.compiler" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.dynalink" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.jconsole" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.jsobject" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.compiler" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.net.http" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.crypto.ec" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.scripting" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.httpserver" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.jdwp.agent" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.localedata" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.management" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.naming.dns" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.naming.rmi" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.instrument" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.management" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.sql.rowset" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.xml.crypto" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.internal.ed" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.internal.le" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.unsupported" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.smartcardio" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.internal.opt" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.datatransfer" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.accessibility" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.hotspot.agent" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.security.auth" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.security.jgss" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.security.jgss" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.security.sasl" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.internal.vm.ci" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.management.jfr" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.management.rmi" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/java.transaction.xa" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.crypto.cryptoki" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.internal.jvmstat" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.management.agent" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.scripting.nashorn" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.unsupported.desktop" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.internal.vm.compiler" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.scripting.nashorn.shell" type="simple" />
+            <root url="jar:///opt/jdk-11/lib/src.zip!/jdk.internal.vm.compiler.management" type="simple" />
           </root>
         </sourcePath>
       </roots>

--- a/config/options/project.default.xml
+++ b/config/options/project.default.xml
@@ -12,9 +12,12 @@
         <property name="GoToClass.includeLibraries" value="false" />
         <property name="GoToClass.toSaveIncludeLibraries" value="false" />
         <property name="GoToFile.includeJavaFiles" value="false" />
-        <property name="MemberChooser.sorted" value="false" />
-        <property name="MemberChooser.showClasses" value="true" />
         <property name="MemberChooser.copyJavadoc" value="false" />
+        <property name="MemberChooser.showClasses" value="true" />
+        <property name="MemberChooser.sorted" value="false" />
+        <property name="project.structure.last.edited" value="SDKs" />
+        <property name="project.structure.proportion" value="0.0" />
+        <property name="project.structure.side.proportion" value="0.0" />
       </component>
       <component name="RunManager">
         <configuration default="true" type="#org.jetbrains.idea.devkit.run.PluginConfigurationType" factoryName="Plugin">
@@ -115,9 +118,43 @@
       </component>
       <component name="masterDetails">
         <states>
+          <state key="GlobalLibrariesConfigurable.UI">
+            <settings>
+              <splitter-proportions>
+                <option name="proportions">
+                  <list>
+                    <option value="0.2" />
+                  </list>
+                </option>
+              </splitter-proportions>
+            </settings>
+          </state>
+          <state key="JdkListConfigurable.UI">
+            <settings>
+              <last-edited>11</last-edited>
+              <splitter-proportions>
+                <option name="proportions">
+                  <list>
+                    <option value="0.2" />
+                  </list>
+                </option>
+              </splitter-proportions>
+            </settings>
+          </state>
           <state key="ProjectJDKs.UI">
             <settings>
               <last-edited>1.8</last-edited>
+              <splitter-proportions>
+                <option name="proportions">
+                  <list>
+                    <option value="0.2" />
+                  </list>
+                </option>
+              </splitter-proportions>
+            </settings>
+          </state>
+          <state key="ProjectLibrariesConfigurable.UI">
+            <settings>
               <splitter-proportions>
                 <option name="proportions">
                   <list>


### PR DESCRIPTION
**Note**: This isn't ready to be merged yet. I'm still testing.

This diff is the result of deleting the existing JDK and adding OpenJDK
11 to the default project structure in the IntelliJ UI.