### PR TITLE
Use OpenJDK 8

### DIFF
--- a/config/options/jdk.table.xml
+++ b/config/options/jdk.table.xml
@@ -3,8 +3,7 @@
     <jdk version="2">
       <name value="1.8" />
       <type value="JavaSDK" />
-      <version value="java version &quot;1.8.0_91&quot;" />
-      <homePath value="/usr/lib/jvm/java-8-oracle" />
+      <homePath value="/usr/lib/jvm/java-8-openjdk-amd64" />
       <roots>
         <annotationsPath>
           <root type="composite">
@@ -13,36 +12,33 @@
         </annotationsPath>
         <classPath>
           <root type="composite">
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/charsets.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/deploy.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/cldrdata.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/dnsns.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/jaccess.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/jfxrt.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/localedata.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/nashorn.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/sunec.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/sunjce_provider.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/sunpkcs11.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/ext/zipfs.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/javaws.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/jce.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/jfr.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/jfxswt.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/jsse.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/management-agent.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/plugin.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/resources.jar!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/jre/lib/rt.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/charsets.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/cldrdata.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/dnsns.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/icedtea-sound.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/jaccess.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/java-atk-wrapper.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/localedata.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/sunec.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/sunjce_provider.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/sunpkcs11.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/zipfs.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jce.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jsse.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/management-agent.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/resources.jar!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/rt.jar!/" type="simple" />
           </root>
         </classPath>
         <javadocPath>
-          <root type="composite" />
+          <root type="composite">
+            <root url="file:///usr/lib/jvm/java-8-openjdk-amd64/docs/api" type="simple" />
+          </root>
         </javadocPath>
         <sourcePath>
           <root type="composite">
-            <root url="jar:///usr/lib/jvm/java-8-oracle/src.zip!/" type="simple" />
-            <root url="jar:///usr/lib/jvm/java-8-oracle/javafx-src.zip!/" type="simple" />
+            <root url="jar:///usr/lib/jvm/java-8-openjdk-amd64/src.zip!/" type="simple" />
           </root>
         </sourcePath>
       </roots>


### PR DESCRIPTION
### What?

- We have switched to OpenJDK 8 and this aligns the IntelliJ config
with that.

### Why?

- We do not want IntelliJ to try and use a JDK that is no longer
available in our dev setup.