### PR TITLE
Disable scala plugin

### DIFF
--- a/config/disabled_plugins.txt
+++ b/config/disabled_plugins.txt
@@ -1,1 +1,2 @@
+org.intellij.scala
 org.jetbrains.kotlin


### PR DESCRIPTION
This plugin causes a lot of false error flags when writing Spark code. To our knowledge (the braintree data engineering team), no one actively uses this plugin, and other teams have also disabled it due to similar issues in their workflows.